### PR TITLE
[FIX] hw_escpos: complying to barcode method A

### DIFF
--- a/addons/hw_escpos/escpos/escpos.py
+++ b/addons/hw_escpos/escpos/escpos.py
@@ -522,6 +522,10 @@ class Escpos:
         # Print Code
         if code:
             self._raw(code)
+            # We are using type A commands
+            # So we need to add the 'NULL' character
+            # https://github.com/python-escpos/python-escpos/pull/98/files#diff-a0b1df12c7c67e38915adbe469051e2dR444
+            self._raw('\x00')
         else:
             raise exception.BarcodeCodeError()
 


### PR DESCRIPTION
Have a XMLReceipt with the line:
<barcode encoding="CODE39">123456789</barcode>

Print the receipt.

Before this commit, jibbrish characters were printed and also kinda 'broke'
the spacing between commands
e.g. If you add an EAN13 barcode below the code39 it would have failed to print correctly too

After this commit, everything prints correctly

OPW 1849284
ref: https://reference.epson-biz.com/modules/ref_escpos/index.php?content_id=128
closes #24965